### PR TITLE
Update JBParallaxCell.podspec (Typo)

### DIFF
--- a/JBParallaxCell.podspec
+++ b/JBParallaxCell.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "JBParallaxCell"
   s.version      = "0.0.1"
-  s.summary      = "This project provides a parallax effect on a `UIImageView` on a `UITAbleViewCell` when the table scrolls."
+  s.summary      = "This project provides a parallax effect on a `UIImageView` on a `UITableViewCell` when the table scrolls."
   s.homepage     = "https://github.com/jberlana/JBParallaxCell"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Javier Berlana" => "https://github.com/jberlana" }


### PR DESCRIPTION
Fixed a typo on `UITAbleViewCell` to `UITableViewCell`
